### PR TITLE
TypeConverter for ArchetypeModel

### DIFF
--- a/app/Umbraco/Archetype.Tests/Archetype.Tests.csproj
+++ b/app/Umbraco/Archetype.Tests/Archetype.Tests.csproj
@@ -263,6 +263,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="PropertyValueConverter\PropertyValueConverterTests.cs" />
     <Compile Include="PublishedContent\ArchetypePublishedContentTests.cs" />
+    <Compile Include="PublishedContent\TypeConverterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/app/Umbraco/Archetype.Tests/PublishedContent/TypeConverterTests.cs
+++ b/app/Umbraco/Archetype.Tests/PublishedContent/TypeConverterTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Archetype.Models;
+using Archetype.PropertyConverters;
+using NUnit.Framework;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+
+namespace Archetype.Tests.PublishedContent
+{
+    [TestFixture]
+    public class TypeConverterTests
+    {
+        private ArchetypeModel _archetype;
+
+        [TestFixtureSetUp]
+        public void Init()
+        {
+            var archetypeJson = System.IO.File.ReadAllText("..\\..\\Data\\sample-1.json");
+            var converter = new ArchetypeValueConverter();
+
+            _archetype = (ArchetypeModel)converter.ConvertDataToSource(null, archetypeJson, false);
+        }
+
+        [TestCase(typeof(ArchetypeModel), true)]
+        [TestCase(typeof(ArchetypePublishedContentSet), true)]
+        [TestCase(typeof(IEnumerable<IPublishedContent>), true)]
+        [TestCase(typeof(string), true)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(ArchetypeFieldsetModel), false)]
+        public void ArchetypeModel_ConvertsTo_EnumerablePublishedContent(Type destinationType, bool expected)
+        {
+            Assert.IsNotNull(_archetype);
+
+            var attempt = _archetype.TryConvertTo(destinationType);
+
+            Assert.That(attempt.Success, Is.EqualTo(expected));
+
+            if (attempt.Success)
+            {
+                Assert.IsNotNull(attempt.Result);
+                Assert.That(attempt.Result, Is.InstanceOf(destinationType));
+            }
+        }
+
+        [TestCase(typeof(ArchetypeFieldsetModel), true)]
+        [TestCase(typeof(ArchetypePublishedContent), true)]
+        [TestCase(typeof(IPublishedContent), true)]
+        [TestCase(typeof(string), true)]
+        [TestCase(typeof(int), false)]
+        [TestCase(typeof(ArchetypeModel), false)]
+        public void ArchetypeFieldsetModel_ConvertsTo_PublishedContent(Type destinationType, bool expected)
+        {
+            CollectionAssert.IsNotEmpty(_archetype.Fieldsets);
+
+            var attempt = _archetype.First().TryConvertTo(destinationType);
+
+            Assert.That(attempt.Success, Is.EqualTo(expected));
+
+            if (attempt.Success)
+            {
+                Assert.IsNotNull(attempt.Result);
+                Assert.That(attempt.Result, Is.InstanceOf(destinationType));
+            }
+        }
+    }
+}

--- a/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
+++ b/app/Umbraco/Umbraco.Archetype/Archetype.Umbraco.csproj
@@ -252,6 +252,8 @@
     <Compile Include="Properties\VersionInfo.cs" />
     <Compile Include="PropertyConverters\ArchetypeValueConverter.cs" />
     <Compile Include="PropertyEditors\ArchetypePropertyEditor.cs" />
+    <Compile Include="TypeConverters\ArchetypeFieldsetModelConverter.cs" />
+    <Compile Include="TypeConverters\ArchetypeModelConverter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeHelper.cs
+++ b/app/Umbraco/Umbraco.Archetype/Extensions/ArchetypeHelper.cs
@@ -98,7 +98,7 @@ namespace Archetype.Extensions
 
                 return archetype;
             }
-            catch
+            catch (Exception ex)
             {
                 return new ArchetypeModel();
             }

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypeFieldsetModel.cs
@@ -1,15 +1,18 @@
+using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Web.Security;
+using Archetype.TypeConverters;
 using Newtonsoft.Json;
 using Umbraco.Core;
-using System;
 
 namespace Archetype.Models
 {
     /// <summary>
     /// Model that represents a fieldset stored as content JSON.
     /// </summary>
+    [TypeConverter(typeof(ArchetypeFieldsetModelConverter))]
     public class ArchetypeFieldsetModel
     {
         [JsonProperty("alias")]
@@ -63,7 +66,7 @@ namespace Archetype.Models
         {
             var property = GetProperty(propertyAlias);
 
-            if (IsEmptyProperty(property)) 
+            if (IsEmptyProperty(property))
             {
                 return default(T);
             }
@@ -87,7 +90,7 @@ namespace Archetype.Models
         {
             var property = GetProperty(propertyAlias);
 
-            if (IsEmptyProperty(property)) 
+            if (IsEmptyProperty(property))
             {
                 return defaultValue;
             }
@@ -100,7 +103,7 @@ namespace Archetype.Models
         /// </summary>
         /// <param name="property">The property.</param>
         /// <returns></returns>
-        private bool IsEmptyProperty(ArchetypePropertyModel property) 
+        private bool IsEmptyProperty(ArchetypePropertyModel property)
         {
             return (property == null || property.Value == null || string.IsNullOrEmpty(property.Value.ToString()));
         }
@@ -145,24 +148,24 @@ namespace Archetype.Models
         /// <returns>true if this fieldset is disabled, false otherwise</returns>
         internal bool IsAvailable()
         {
-			// explicitly disabled or implicitly disabled through publishing?
-	        var disabled = Disabled
+            // explicitly disabled or implicitly disabled through publishing?
+            var disabled = Disabled
                    || (ReleaseDate.HasValue && ReleaseDate > DateTime.UtcNow)
                    || (ExpireDate.HasValue && DateTime.UtcNow > ExpireDate);
-	        if(disabled)
-	        {
-	            // yes - the fieldset is not available
-	            return false;
-	        }
-	        // limitation on member group access?
-	        if(string.IsNullOrEmpty(AllowedMemberGroups))
-	        {
-	            // no - the fieldset is available
-	            return true;
-	        }
-	        // maybe - the fieldset is available if the current member is a member of the configured member groups
-	        var currentUserGroups = Roles.GetRolesForUser() ?? new string[0];
-	        return currentUserGroups.ContainsAny(AllowedMemberGroups.Split(','));
+            if (disabled)
+            {
+                // yes - the fieldset is not available
+                return false;
+            }
+            // limitation on member group access?
+            if (string.IsNullOrEmpty(AllowedMemberGroups))
+            {
+                // no - the fieldset is available
+                return true;
+            }
+            // maybe - the fieldset is available if the current member is a member of the configured member groups
+            var currentUserGroups = Roles.GetRolesForUser() ?? new string[0];
+            return currentUserGroups.ContainsAny(AllowedMemberGroups.Split(','));
         }
 
         #endregion

--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypeModel.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypeModel.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
+using Archetype.TypeConverters;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
@@ -11,6 +13,7 @@ namespace Archetype.Models
     /// Model that represents an entire Archetype.
     /// </summary>
     [JsonObject]
+    [TypeConverter(typeof(ArchetypeModelConverter))]
     public class ArchetypeModel : IEnumerable<ArchetypeFieldsetModel>
     {
         [JsonProperty("fieldsets")]

--- a/app/Umbraco/Umbraco.Archetype/TypeConverters/ArchetypeFieldsetModelConverter.cs
+++ b/app/Umbraco/Umbraco.Archetype/TypeConverters/ArchetypeFieldsetModelConverter.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using Archetype.Extensions;
+using Archetype.Models;
+using Umbraco.Core.Models;
+
+namespace Archetype.TypeConverters
+{
+    public class ArchetypeFieldsetModelConverter : TypeConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(IPublishedContent) ||
+                destinationType == typeof(ArchetypePublishedContent))
+            {
+                return true;
+            }
+
+            if (destinationType == typeof(string))
+            {
+                // NOTE: The converter needs to return false here, otherwise `ArchetypeHelper.DeserializeJsonToArchetype` fails.
+                return false;
+            }
+
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (value is ArchetypeFieldsetModel && (destinationType == typeof(IPublishedContent) || destinationType == typeof(ArchetypePublishedContent)))
+            {
+                return ((ArchetypeFieldsetModel)value).ToPublishedContent();
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}

--- a/app/Umbraco/Umbraco.Archetype/TypeConverters/ArchetypeModelConverter.cs
+++ b/app/Umbraco/Umbraco.Archetype/TypeConverters/ArchetypeModelConverter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using Archetype.Extensions;
+using Archetype.Models;
+using Umbraco.Core.Models;
+
+namespace Archetype.TypeConverters
+{
+    public class ArchetypeModelConverter : TypeConverter
+    {
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            if (destinationType == typeof(ArchetypePublishedContentSet) ||
+                destinationType == typeof(IEnumerable<IPublishedContent>))
+            {
+                return true;
+            }
+
+            return base.CanConvertTo(context, destinationType);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            if (value is ArchetypeModel && (destinationType == typeof(ArchetypePublishedContentSet) || destinationType == typeof(IEnumerable<IPublishedContent>)))
+            {
+                return ((ArchetypeModel)value).ToPublishedContentSet();
+            }
+
+            return base.ConvertTo(context, culture, value, destinationType);
+        }
+    }
+}


### PR DESCRIPTION
Added a TypeConverter for both `ArchetypeModel` and `ArchetypeFieldsetModel`, so that they can be converted to their `IPublishedContent` equivalent.

Example usage would be, when you would typically do this...

``` csharp
var items = Model.Content.GetPropertyValue<ArchetypeModel>myArchetypeAlias");
```

You can now do this...

``` csharp
var items = Model.Content.GetPropertyValue<IEnumerable<IPublishedContent>>("myArchetypeAlias");
```

I know it seems more verbose, but the idea is that this could be hot-swappable with other property-editors, such as Nested Content. The frontend/code would deal purely with `IPublishedContent` objects.

---

Also included unit-tests that run via Umbraco Core's `TryConvertTo` extension method, (which is what `Content.GetPropertyValue<T>` uses internally in Umbraco).

There's a small caveat with the TypeConverter for `ArchetypeFieldsetModel`, I had to explicitly reject `typeof(string)`, otherwise the JSON deserializer fails (in `ArchetypeHelper.DeserializeJsonToArchetype`).
All other unit-tests still pass.
