### PR TITLE
Updating the source scope to properly look at the ui item parent

### DIFF
--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -91,7 +91,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
 
             // Variables.
             var targetScope = ui.item.sortable.droptarget.scope();
-            var sourceScope = ui.item.scope();
+            var sourceScope = ui.item.parent().scope();
             var sameScope = sourceScope === targetScope;
             var sourceIndex = ui.item.sortable.index;
 


### PR DESCRIPTION
**Steps to reproduce bug**
1. Create an archetype property editor that has a max fieldset validation on (in my case, it was 3)
2. Add max elements (in my case 3) to that archetype on a content item in the CMS
3. Note that you can no longer reorder / sort the elements within that archetype collection.

I noticed an issue when I had max fieldset validation turned on where when I have an archetype collection at max, I can't drag and drop within the same archetype in order to reorder the collection. I found that the code was dropping into the logic section that should be used to handle dragging and dropping between different Archetypes, which wasn't my case. 

``` javascript
    // Special constraints for when moving between Archetypes.
    // If sourceScope is populated, we are in the first of the two updates (when
    // moving between lists, ui-sortable calls the update function twice).
    if (sourceScope && !sameScope) { 
    .... [ code was reaching here because sameScope was false ]
    }
```

This led me to look at how `sameScope` was being derived, and I found that in every case, it was false because it was comparing a child scope to a parent scope.

I updated it to compare the correct scope levels and things appear to work as expected now.