### PR TITLE
Subheadings were not being rendered correctly in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Install the selected <a href='https://github.com/imulus/Archetype/releases'>rele
 https://github.com/kgiszewski/ArchetypeManual
 
 
-##News and Updates##
+## News and Updates ##
 Follow us on Twitter https://twitter.com/ArchetypeKit
 
-##Core Team##
+## Core Team ##
 * Kevin Giszewski (founder/project lead) - University of Notre Dame - https://kevin.giszewski.com/
 * Tom Fulton (founder) - Tonic - http://hellotonic.com/
 * Lee Kelleher - Umbrella - http://www.umbrellainc.co.uk/


### PR DESCRIPTION
Tidied up markdown formatting on the readme, because a couple of the subheadings were not being displayed correctly.