### PR TITLE
Multiple open fieldsets

### DIFF
--- a/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValue.cs
+++ b/app/Umbraco/Umbraco.Archetype/Models/ArchetypePreValue.cs
@@ -25,6 +25,9 @@ namespace Archetype.Models
         [JsonProperty("enableCollapsing")]
         public bool EnableCollapsing { get; set; }
 
+        [JsonProperty("enableMultipleOpen")]
+        public bool EnableMultipleOpen { get; set; }
+
         [JsonProperty("enableCloning")]
         public bool EnableCloning { get; set; }
 

--- a/app/controllers/config.controller.js
+++ b/app/controllers/config.controller.js
@@ -6,7 +6,7 @@ angular.module("umbraco").controller("Imulus.ArchetypeConfigController", functio
     //define empty items
     var newPropertyModel = '{"alias": "", "remove": false, "collapse": false, "label": "", "helpText": "", "dataTypeGuid": "0cc0eba1-9960-42c9-bf9b-60e150b429ae", "value": ""}';
     var newFieldsetModel = '{"alias": "", "remove": false, "collapse": false, "labelTemplate": "", "icon": "", "label": "", "properties": [' + newPropertyModel + '], "group": null}';
-    var defaultFieldsetConfigModel = JSON.parse('{"showAdvancedOptions": false, "startWithAddButton": false, "hideFieldsetToolbar": false, "enableMultipleFieldsets": false, "hideFieldsetControls": false, "hidePropertyLabel": false, "maxFieldsets": null, "enableCollapsing": true, "enableCloning": false, "enableDisabling": true, "enableDeepDatatypeRequests": false, "enablePublishing": false, "enableMemberGroups": false, "enableCrossDragging": false, "fieldsets": [' + newFieldsetModel + '], "fieldsetGroups": []}');
+    var defaultFieldsetConfigModel = JSON.parse('{"showAdvancedOptions": false, "startWithAddButton": false, "hideFieldsetToolbar": false, "enableMultipleFieldsets": false, "hideFieldsetControls": false, "hidePropertyLabel": false, "maxFieldsets": null, "enableCollapsing": true, "enableMultipleOpen": true, "enableCloning": false, "enableDisabling": true, "enableDeepDatatypeRequests": false, "enablePublishing": false, "enableMemberGroups": false, "enableCrossDragging": false, "fieldsets": [' + newFieldsetModel + '], "fieldsetGroups": []}');
 
     //ini the model
     $scope.model.value = $scope.model.value || defaultFieldsetConfigModel;

--- a/app/controllers/controller.js
+++ b/app/controllers/controller.js
@@ -597,16 +597,16 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
             return;
         }
 
-        var iniState;
-
-        if(fieldset)
+        // collapse all other fieldsets if "multiple open fieldsets" is not enabled
+        if(!$scope.model.config.enableMultipleOpen) 
         {
-            iniState = fieldset.collapse;
+            _.each($scope.model.value.fieldsets, function (f) {
+                if(f != fieldset)
+                {
+                    f.collapse = true;
+                }
+            });
         }
-
-        _.each($scope.model.value.fieldsets, function(fieldset){
-            fieldset.collapse = true;
-        });
 
         if(!fieldset && $scope.model.value.fieldsets.length == 1)
         {
@@ -615,10 +615,13 @@ angular.module("umbraco").controller("Imulus.ArchetypeController", function ($sc
             return;
         }
 
-        if(iniState && fieldset)
+        if(fieldset)
         {
-            fieldset.collapse = !iniState;
-            $scope.loadedFieldsets.push(fieldset);
+            fieldset.collapse = !fieldset.collapse;
+            if($scope.loadedFieldsets.indexOf(fieldset) < 0)
+            {
+                $scope.loadedFieldsets.push(fieldset);
+            }
         }
     }
 

--- a/app/views/archetype.config.fieldset.dialog.html
+++ b/app/views/archetype.config.fieldset.dialog.html
@@ -12,6 +12,9 @@
             <label for="archetypeAdvancedOptionsCollapsing"><input type="checkbox" id="archetypeAdvancedOptionsCollapsing" ng-model="dialogData.model.enableCollapsing"/><archetype-localize key="enableCollapsing">Enable Collapsing?</archetype-localize><small><archetype-localize key="enableCollapsingDescription">Enable fieldset collapsing.</archetype-localize></small></label>
         </div>
         <div>
+            <label for="archetypeAdvancedOptionsMultipleOpen"><input type="checkbox" id="archetypeAdvancedOptionsMultipleOpen" ng-model="dialogData.model.enableMultipleOpen" /><archetype-localize key="enableMultipleOpen">Enable Multiple Open Fieldsets?</archetype-localize><small><archetype-localize key="enableMultipleOpenDescription">When fieldset collapsing is enabled, this allows multiple fieldsets to be open at the same time.</archetype-localize></small></label>
+        </div>
+        <div>
             <label for="archetypeAdvancedOptionsMaxFieldsets"><archetype-localize key="maxFieldsets">Max Fieldsets</archetype-localize><small><archetype-localize key="maxFieldsetsDescription">How many Fieldsets are allowed? Entering '1' will disable the controls. Default is unlimited.</archetype-localize></small></label>
             <input type="number" id="archetypeAdvancedOptionsMaxFieldsets" class="archetypeMaxFieldsets" ng-model="dialogData.model.maxFieldsets"/>
         </div>


### PR DESCRIPTION
Enable multiple open fieldsets by datatype configuration. It's default enabled on newly created Archetypes.

This fixes #196.