### PR TITLE
Fix #417

### DIFF
--- a/app/directives/archetypeproperty.js
+++ b/app/directives/archetypeproperty.js
@@ -65,7 +65,8 @@ angular.module("umbraco.directives").directive('archetypeProperty', function ($c
 
                     if (!scope.renderModelPropertyIndex)
                     {
-                        archetypeService.getFieldset(scope).properties.push(JSON.parse('{"alias": "' + alias + '", "value": "' + defaultValue + '"}'));
+                        var propertyValue = { alias: alias, value: defaultValue };
+                        archetypeService.getFieldset(scope).properties.push(propertyValue);
                         scope.renderModelPropertyIndex = archetypeService.getPropertyIndexByAlias(archetypeService.getFieldset(scope).properties, alias);
                     }
 


### PR DESCRIPTION
This makes it possible to supply JSON as default value to a property within a fieldset.

**Note:** The JSON must validate with https://jsonlint.com/ - among other things, this means wrapping all property names in quotes. For example: `{"property1": "test", "property2": 123}` instead of `{property1: "test", property2: 123}`.